### PR TITLE
feat: add endpoint for frontend configuration

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -50,6 +50,11 @@
             <optional>true</optional>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <optional>true</optional>
+        </dependency>
+        <dependency>
             <groupId>org.postgresql</groupId>
             <artifactId>postgresql</artifactId>
             <scope>runtime</scope>

--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/AppConfigProperties.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/AppConfigProperties.java
@@ -1,0 +1,12 @@
+package de.snookersbuddy.snookersbuddyserver.infrastructure.spring;
+
+import lombok.Data;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@ConfigurationProperties(prefix = "appconfig")
+@Data
+public class AppConfigProperties {
+    private boolean debug;
+}

--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/appconfig/AppConfigController.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/appconfig/AppConfigController.java
@@ -1,0 +1,19 @@
+package de.snookersbuddy.snookersbuddyserver.ports.rest.appconfig;
+
+import de.snookersbuddy.snookersbuddyserver.infrastructure.spring.AppConfigProperties;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class AppConfigController {
+    private final AppConfigProperties appConfigProperties;
+
+    public AppConfigController(AppConfigProperties appConfigProperties) {
+        this.appConfigProperties = appConfigProperties;
+    }
+
+    @GetMapping("/api/appconfig")
+    public GetAppConfigOutput getAppConfig() {
+        return new GetAppConfigOutput(appConfigProperties.isDebug());
+    }
+}

--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/appconfig/GetAppConfigOutput.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/appconfig/GetAppConfigOutput.java
@@ -1,0 +1,4 @@
+package de.snookersbuddy.snookersbuddyserver.ports.rest.appconfig;
+
+public record GetAppConfigOutput(boolean debug) {
+}

--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -12,12 +12,10 @@ spring.jpa.show-sql=true
 
 management.endpoints.web.exposure.include=prometheus
 management.endpoints.web.base-path=/api
-
-
-
 # Port 8080 is so widely used, it's better go to with something unique.
 server.port=28080
-
 adminlogin.enabled=false
 adminlogin.user.name=admin
 adminlogin.user.password=$2a$10$YTW3Sn2jQ0ZS0tj4MLInnuyX.OCSlMGcYwfeuXOgagW5ny8VOc.1C
+# Appconfig is all the configuration related to the frontend.
+appconfig.debug=${SB_APP_DEBUG:false}


### PR DESCRIPTION
Add an endpoint for all frontend related configuration data (called `appconfig`).
This is needed to instruct the frontend when to show things like the new debug menu.