### PR TITLE
feat: secure monitoring endpoint via basic auth

### DIFF
--- a/app/pom.xml
+++ b/app/pom.xml
@@ -76,6 +76,10 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-security</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.flywaydb</groupId>
             <artifactId>flyway-core</artifactId>
         </dependency>

--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/SecurityConfig.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/SecurityConfig.java
@@ -1,0 +1,42 @@
+package de.snookersbuddy.snookersbuddyserver.infrastructure.spring;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.User.UserBuilder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        return http
+            .authorizeHttpRequests().requestMatchers("/api/prometheus/**").authenticated().and().httpBasic()
+            .and()
+            .authorizeHttpRequests().requestMatchers("/**").permitAll()
+            .and()
+            .build();
+    }
+
+    @Bean
+    public UserDetailsService users() {
+        final UserBuilder users = User.withDefaultPasswordEncoder();
+        final UserDetails apiuser = users
+            // FIXME: Obviously not ready for production
+            .username("prometheus")
+            .password("prometheus")
+            .roles("MONITORING")
+            .build();
+        return new InMemoryUserDetailsManager(apiuser);
+    }
+
+}

--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/SecurityConfig.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/infrastructure/spring/SecurityConfig.java
@@ -20,7 +20,7 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         return http
-            .authorizeHttpRequests().requestMatchers("/api/prometheus/**").authenticated().and().httpBasic()
+            .authorizeHttpRequests().requestMatchers("/api/prometheus/**").hasRole("MONITORING").and().httpBasic()
             .and()
             .authorizeHttpRequests().requestMatchers("/**").permitAll()
             .and()
@@ -30,8 +30,8 @@ public class SecurityConfig {
     @Bean
     public UserDetailsService users() {
         final UserBuilder users = User.withDefaultPasswordEncoder();
+        // FIXME: Obviously not ready for production
         final UserDetails apiuser = users
-            // FIXME: Obviously not ready for production
             .username("prometheus")
             .password("prometheus")
             .roles("MONITORING")


### PR DESCRIPTION
Not ready for production, but enough to get it up and running based on: https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/basic.html

Long term the credentials should be stored in our database via JDBC instead of hardcoded in-memory:
https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/storage.html

The general configuration class can be reused for our intended login security form, see in general:
https://docs.spring.io/spring-security/reference/servlet/authentication/index.html


To test this feature:
```bash
# before
⋟ http localhost:28080/api/prometheus
HTTP/1.1 200
Connection: keep-alive
Content-Length: 24106
Content-Type: text/plain;version=0.0.4;charset=utf-8
Date: Sun, 23 Apr 2023 17:20:02 GMT
Keep-Alive: timeout=60

# after: no credentials
⋟ http localhost:28080/api/prometheus
HTTP/1.1 401
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: keep-alive
Content-Type: application/json
Date: Sun, 23 Apr 2023 17:45:52 GMT
Expires: 0
Keep-Alive: timeout=60
Pragma: no-cache
Transfer-Encoding: chunked
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
WWW-Authenticate: Basic realm="Realm"
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0

{
    "error": "Unauthorized",
    "message": "Unauthorized",
    "path": "/api/prometheus",
    "status": 401,
    "timestamp": "2023-04-23T17:45:52.703+00:00"
}

# after: wrong credentials
⋟ http localhost:28080/api/prometheus --auth prometheus:wrong
HTTP/1.1 401
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: keep-alive
Content-Type: application/json
Date: Sun, 23 Apr 2023 17:45:52 GMT
Expires: 0
Keep-Alive: timeout=60
Pragma: no-cache
Transfer-Encoding: chunked
Vary: Origin, Access-Control-Request-Method, Access-Control-Request-Headers
WWW-Authenticate: Basic realm="Realm"
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0

{
    "error": "Unauthorized",
    "message": "Unauthorized",
    "path": "/api/prometheus",
    "status": 401,
    "timestamp": "2023-04-23T17:45:52.703+00:00"
}

# after: correct credentials
⋟ http localhost:28080/api/prometheus --auth prometheus:prometheus
HTTP/1.1 200
Cache-Control: no-cache, no-store, max-age=0, must-revalidate
Connection: keep-alive
Content-Length: 44021
Content-Type: text/plain;version=0.0.4;charset=utf-8
Date: Sun, 23 Apr 2023 17:45:58 GMT
Expires: 0
Keep-Alive: timeout=60
Pragma: no-cache
X-Content-Type-Options: nosniff
X-Frame-Options: DENY
X-XSS-Protection: 0
```

Other endpoints should not be affected.

One small remark: This was written without any lint/format/importer IDE stuff, so feel free to restyle, change imports etc. to make it adhere to our standards.