### PR TITLE
Draft: Clean & Migrate programmatically

### DIFF
--- a/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/admin/TableController.java
+++ b/app/src/main/java/de/snookersbuddy/snookersbuddyserver/ports/rest/admin/TableController.java
@@ -5,7 +5,10 @@ import de.snookersbuddy.snookersbuddyserver.application.item.ItemService;
 import de.snookersbuddy.snookersbuddyserver.application.option.OptionService;
 import de.snookersbuddy.snookersbuddyserver.application.variant.VariantService;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import org.flywaydb.core.Flyway;
 
 @RestController
 public class TableController {
@@ -28,5 +31,22 @@ public class TableController {
     @GetMapping("/api/table-data")
     public GetTableDataOutput getOptions() {
         return this.itemService.getTableData();
+    }
+
+    @PostMapping("/api/reset-data")
+    public void resetData() {
+        Flyway flyway =
+            Flyway.configure()
+            // FIXME: Not suited for production
+            .dataSource("jdbc:postgresql://localhost:25432/snookers" , "snookers" , "snookers")
+            // TODO: Should be moved to properties and set to true in production
+            .cleanDisabled(false)
+            .load()
+            ;
+
+        // Start the migration
+        flyway.clean();
+        flyway.migrate();
+
     }
 }


### PR DESCRIPTION
Of course this is be no means finished, but as a spike I looked into how to call Flyway programmatically and was able to clean and migrate quite easily, removing manually created orders in the process.
I would suggest the following:

1. Move this to a viable place in code
1. Add a small button somewhere (admin overview?) to trigger this
1. Create some plausible orders relative to the current time

What do you think?