### PR TITLE
refactor: Suppress Hibernate session logs

### DIFF
--- a/app/src/main/resources/application.properties
+++ b/app/src/main/resources/application.properties
@@ -14,7 +14,8 @@ management.endpoints.web.exposure.include=prometheus
 management.endpoints.web.base-path=/api
 # Allows to explicitly monitor available statistics: https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.metrics.supported.tomcat
 server.tomcat.mbeanregistry.enabled=true
-spring.jpa.properties[hibernate.generate_statistics]=true
+spring.jpa.properties.hibernate.generate_statistics=true
+spring.jpa.properties.hibernate.session.events.log=false
 
 # Port 8080 is so widely used, it's better go to with something unique.
 server.port=28080


### PR DESCRIPTION
Quick test - Same amount of metrics exposed for me while keep the log clean:

```bash
http localhost:28080/api/prometheus | rg --count hibernate\|jdbc 102
```

Fun fact: Took me around 20 properties to mangle with until I found the right one...